### PR TITLE
Fix misprint

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,7 +33,7 @@ export default class App extends React.Component {
   };
 
   onDragEnd = () => {
-    this.draggedIdx = null;
+    this.draggedItem = null;
   };
 
   render() {


### PR DESCRIPTION
When dragging is completed, the draggable element (`draggedItem`) must be set to null, but `draggedIdx` is set instead, although such a variable does not even exist. Most likely this is a misprint.